### PR TITLE
remove hard dependency upon framework-core

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -142,6 +142,7 @@
       <groupId>org.ccci</groupId>
       <artifactId>framework-core</artifactId>
       <version>2.0-SNAPSHOT</version>
+      <optional>true</optional>
     </dependency>
     
     <dependency>
@@ -167,7 +168,12 @@
       <artifactId>javax.inject</artifactId>
       <version>1</version>
     </dependency>
-    
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <version>14.0.1</version>
+    </dependency>
+
   </dependencies>
   
   <properties>

--- a/src/main/java/org/ccci/framework/sblio/BusComp.java
+++ b/src/main/java/org/ccci/framework/sblio/BusComp.java
@@ -1,14 +1,13 @@
 package org.ccci.framework.sblio;
 
-import java.lang.reflect.Field;
-import java.util.List;
-
-import org.ccci.framework.sblio.annotations.BusinessComp;
-import org.ccci.util.Util;
-
+import com.google.common.base.Strings;
 import com.siebel.data.SiebelBusComp;
 import com.siebel.data.SiebelBusObject;
 import com.siebel.data.SiebelException;
+import org.ccci.framework.sblio.annotations.BusinessComp;
+
+import java.lang.reflect.Field;
+import java.util.List;
 
 public class BusComp
 {
@@ -171,7 +170,6 @@ public class BusComp
      * used by:
      * 		-siebelSelect
      * 		-siebelListSelect
-     * @param siebelPersistenceImpl TODO
      * @param obj
      * @param keyMatters (for distinguishing b/w plain select & select for an update)
      * @return
@@ -195,7 +193,7 @@ public class BusComp
                     	Object fieldValueObject = SiebelHelper.getFieldValueFromAccessibleField(obj, field);
                     	String fieldName = SiebelHelper.getFieldName(field);
                     	String fieldValue = SiebelHelper.convertFieldValueToSiebelValue(field,fieldValueObject);
-                    	if(!Util.isBlank(fieldValue))
+                    	if(!Strings.isNullOrEmpty(fieldValue))
                     	{
                     		emptyQuery = false;
                     		setSearchSpec(fieldName,fieldValue);

--- a/src/main/java/org/ccci/framework/sblio/SiebelHelper.java
+++ b/src/main/java/org/ccci/framework/sblio/SiebelHelper.java
@@ -7,10 +7,9 @@ import java.util.Date;
 import java.util.EnumSet;
 import java.util.List;
 
+import com.google.common.base.Strings;
 import org.ccci.framework.sblio.annotations.SiebelField;
 import org.ccci.framework.sblio.annotations.SiebelFieldValue;
-import org.ccci.util.StringUtil;
-import org.ccci.util.Util;
 import org.joda.time.DateTime;
 import org.joda.time.LocalDate;
 
@@ -33,7 +32,7 @@ public class SiebelHelper
      */
     public static String convertCamelCaseToSpaces(String camelCase)
     {
-    	if(Util.isBlank(camelCase)) return camelCase;
+    	if(Strings.isNullOrEmpty(camelCase)) return camelCase;
     	
         StringBuffer spaces = new StringBuffer();
 
@@ -209,7 +208,7 @@ public class SiebelHelper
         }
         else
         {
-            if (StringUtil.isBlank(fieldValue))
+            if (Strings.isNullOrEmpty(fieldValue))
             {
                 return null;
             }
@@ -243,7 +242,7 @@ public class SiebelHelper
             {
                 return parseLocalDate(fieldValue);
             }
-            else if(Enum.class.isAssignableFrom(fieldType) && !Util.isBlank(fieldValue))
+            else if(Enum.class.isAssignableFrom(fieldType) && !Strings.isNullOrEmpty(fieldValue))
             {
                 @SuppressWarnings("rawtypes")  //sadly, I think using asSubclass() requires us to use a raw type
                 Class<? extends Enum> enumType = fieldType.asSubclass(Enum.class);

--- a/src/main/java/org/ccci/framework/sblio/SiebelPersistenceFactory.java
+++ b/src/main/java/org/ccci/framework/sblio/SiebelPersistenceFactory.java
@@ -1,15 +1,14 @@
 package org.ccci.framework.sblio;
 
-import javax.inject.Inject;
-
+import com.google.common.base.Strings;
+import com.siebel.data.SiebelException;
 import org.apache.commons.pool.BasePoolableObjectFactory;
 import org.apache.log4j.Logger;
 import org.ccci.framework.failover.CcciFailoverManager;
 import org.ccci.framework.sblio.annotations.Siebel;
 import org.ccci.framework.sblio.exceptions.SiebelUnavailableException;
-import org.ccci.util.Util;
 
-import com.siebel.data.SiebelException;
+import javax.inject.Inject;
 
 public class SiebelPersistenceFactory extends BasePoolableObjectFactory
 {
@@ -61,7 +60,7 @@ public class SiebelPersistenceFactory extends BasePoolableObjectFactory
     	{
     	    SiebelPersistence persistence;
     		url = SiebelSettings.getProps().getProperty(system + "." + "url");
-    		if(Util.isBlank(username)) username = SiebelSettings.getProps().getProperty(system + "." + "defaultUser");
+    		if(Strings.isNullOrEmpty(username)) username = SiebelSettings.getProps().getProperty(system + "." + "defaultUser");
     		password = SiebelSettings.getProps().getProperty(system + "." + username);
     		
     		if(this.failoverManager == null)

--- a/src/main/java/org/ccci/framework/sblio/SiebelPersistenceImpl.java
+++ b/src/main/java/org/ccci/framework/sblio/SiebelPersistenceImpl.java
@@ -1,21 +1,18 @@
 package org.ccci.framework.sblio;
 
-import java.lang.reflect.Field;
-
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-
-import org.ccci.exceptions.FatalException;
+import com.siebel.data.SiebelBusObject;
+import com.siebel.data.SiebelDataBean;
+import com.siebel.data.SiebelException;
 import org.ccci.framework.sblio.annotations.BusinessComp;
 import org.ccci.framework.sblio.annotations.BusinessObject;
 import org.ccci.framework.sblio.annotations.ChildBusinessCompField;
 import org.ccci.framework.sblio.annotations.MvgField;
 import org.ccci.framework.sblio.exceptions.SiebelUnavailableException;
 
-import com.siebel.data.SiebelBusObject;
-import com.siebel.data.SiebelDataBean;
-import com.siebel.data.SiebelException;
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
 
 /**
  * 
@@ -795,8 +792,6 @@ public class SiebelPersistenceImpl implements SiebelPersistence
 	 * @return
 	 * @throws SiebelException
 	 * @throws IllegalAccessException
-	 * @throws FatalException -- could come from this method (failed query) or
-	 *             populateBusinessComp
 	 */
 	private BusComp setupForQuery(Object obj, boolean forUpdate) throws SiebelException
 	{

--- a/src/main/java/org/ccci/framework/sblio/SiebelSettings.java
+++ b/src/main/java/org/ccci/framework/sblio/SiebelSettings.java
@@ -1,13 +1,15 @@
 package org.ccci.framework.sblio;
 
+import com.google.common.io.Resources;
+import org.apache.log4j.Logger;
+
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Properties;
-
-import org.apache.log4j.Logger;
-import org.ccci.util.CommaList;
-import org.ccci.util.LoadFromClasspath;
 
 public class SiebelSettings
 {
@@ -40,11 +42,7 @@ public class SiebelSettings
     public static void reloadProperties() throws IOException
     {
     	props = new Properties();
-        InputStream propertiesStream = LoadFromClasspath.getStream(siebelPropertiesFilename);
-        if (propertiesStream == null)
-        {
-            throw new IllegalStateException("No " + siebelPropertiesFilename + " on classpath!");
-        }
+        InputStream propertiesStream = Resources.getResource("/" + siebelPropertiesFilename).openStream();
         try
         {
             props.load(propertiesStream);
@@ -59,7 +57,10 @@ public class SiebelSettings
         // load the list of users that we should pool... this is actually
         // used by DbioList.  the list is also converted to lowercase for
         // easier comparison
-        pooledUsers = new CommaList(props.getProperty("pooledUserList"));
+        String pooledUserList = props.getProperty("pooledUserList");
+        pooledUsers = pooledUserList == null ?
+           Collections.emptyList() :
+           Arrays.asList(pooledUserList.trim().split("\\s*,\\s*"));
 
         for(int i=0; i<pooledUsers.size(); i++)
         {

--- a/src/main/java/org/ccci/framework/sblio/SiebelUtil.java
+++ b/src/main/java/org/ccci/framework/sblio/SiebelUtil.java
@@ -1,15 +1,15 @@
 package org.ccci.framework.sblio;
 
-import java.lang.reflect.Field;
-
+import com.google.common.base.Strings;
 import org.ccci.framework.sblio.annotations.ChildBusinessCompField;
 import org.ccci.framework.sblio.annotations.Key;
 import org.ccci.framework.sblio.annotations.MvgField;
 import org.ccci.framework.sblio.annotations.ReadOnly;
 import org.ccci.framework.sblio.annotations.Transient;
-import org.ccci.util.Util;
 import org.joda.time.format.DateTimeFormat;
 import org.joda.time.format.DateTimeFormatter;
+
+import java.lang.reflect.Field;
 
 public class SiebelUtil
 {
@@ -63,7 +63,7 @@ public class SiebelUtil
         Field field = SiebelHelper.getField(parentObj.getClass(), fieldName);
         if(field==null) return fieldName;
         MvgField fieldMetadata = field.getAnnotation(MvgField.class);
-        if(fieldMetadata!=null && !Util.isBlank(fieldMetadata.name())) siebelFieldName = fieldMetadata.name();
+        if(fieldMetadata!=null && !Strings.isNullOrEmpty(fieldMetadata.name())) siebelFieldName = fieldMetadata.name();
         return siebelFieldName;
     }
 
@@ -73,7 +73,7 @@ public class SiebelUtil
         Field field = SiebelHelper.getField(parentObj.getClass(), fieldName);
         if(field==null) return fieldName;
         ChildBusinessCompField fieldMetadata = field.getAnnotation(ChildBusinessCompField.class);
-        if(fieldMetadata!=null && !Util.isBlank(fieldMetadata.name())) siebelFieldName = fieldMetadata.name();
+        if(fieldMetadata!=null && !Strings.isNullOrEmpty(fieldMetadata.name())) siebelFieldName = fieldMetadata.name();
         return siebelFieldName;
     }
 }


### PR DESCRIPTION
- most of its functionality is easily replaced by guava or jdk utilities
- PooledSiebelResourceProvider is the only class using framework-core classes
  — client using it must manually specify a dependency upon framework-core
